### PR TITLE
Update to remove error for South African Data

### DIFF
--- a/DataProcessing/e01_gen_yield_polygons.Rmd
+++ b/DataProcessing/e01_gen_yield_polygons.Rmd
@@ -144,7 +144,9 @@ dist_test <- yield %>%
 # we want to see if the converted units from ft to meter are closer to the distance measured in r
 if (mean(dist_test$dif_distance_conv, na.rm = TRUE) < mean(dist_test$dif_distance, na.rm = TRUE)){
   units <- "imperial"
-}
+}else{
+  units <- "metric"
+  }
 ```
 
 ### transform measurement unit
@@ -158,6 +160,8 @@ if (units == "imperial") {
       distance = conv_unit(distance, "ft", "m"),
       offset = conv_unit(offset, "ft", "m")
     )
+}else{
+  yield <- yield
 }
 
 ```


### PR DESCRIPTION
South African data will produce errors with the current code. We need to add a unit name when it is in metric as well. Right now, we don't do this explicitly. It won't affect the rest of the code, but we don't want the error produced to confuse people.