### PR TITLE
Update Width Correction when section_num == 1

### DIFF
--- a/DataProcessing/e02_process_as_applied_base.Rmd
+++ b/DataProcessing/e02_process_as_applied_base.Rmd
@@ -336,13 +336,8 @@ if (section_num != 1) {
   aa_input_grouped <- mutate(aa_input_grouped, width = med_distance_h)
 
 } else {
-  # if only one observation 
-  aa_input_grouped <- mutate(aa_input_grouped, 
-    width = trial_info %>% 
-      filter(input_type == "input_type_here") %>% 
-      .$machine_width %>% 
-      conv_unit("ft", "m")
-  )
+  # if only one observation at a timestamp, use the reported width from the machine 
+  aa_input_grouped <- aa_input_grouped
 } 
 ```
 


### PR DESCRIPTION
When there is only one section, we do not need to retrieve the machine width from the field_data. The field data doesn't specify units for the machinery width, but the current code assumes the machinery width is in feet. I think it is better to grab the width from the asapplied data, where we have already identified the units and converted the width to meters. This also avoids allowing any entry error in field_parameters to affect the polygons created in the final step.