### PR TITLE
Update to exclude values of 0 in the input_rate

### DIFF
--- a/Analysis/a01_analysis.Rmd
+++ b/Analysis/a01_analysis.Rmd
@@ -154,7 +154,7 @@ analysis_res_g <- trial_info %>%
   ) %>% 
   mutate(
     data = list(
-      run_gwr(data, "input_rate") 
+      run_gwr(subset(data, input_rate != 0), "input_rate")  
     )
   ) 
 


### PR DESCRIPTION
We need to eliminate any 0 values in the input rate before running gwr with log(input_rate)