### PR TITLE
Farmer prices when running unpack_field_parameters

### DIFF
--- a/Functions/unpack_field_parameters.R
+++ b/Functions/unpack_field_parameters.R
@@ -29,8 +29,8 @@ input_data <- dplyr::select(w_field_data, starts_with(
 #/*----------------------------------*/
 crop <- w_field_data[, crop] 
 crop_unit <- w_field_data[, crop_unit] 
-crop_price <- w_field_data[, crop_price] 
-if(!is.numeric(crop_price)) {
+crop_price <- as.numeric(w_field_data[, crop_price]) 
+if(is.na(crop_price) == TRUE) {
   crop_price <- case_when(
     crop == "soy" ~ 14, # $/bu
     crop == "corn" ~ 5.5, # $/bu
@@ -94,9 +94,9 @@ if (process_s) {
   #++++++++++++++++
   # seed price
   #++++++++++++++++
-  s_price <- input_data_s[, price]
+  s_price <- as.numeric(input_data_s[, price])
 
-  if(!is.numeric(s_price)) {
+  if(is.na(s_price) == TRUE) {
     #=== default price ===#
     if (crop == "corn") {
       s_price <- 0.00381 * 1000 # (thousand seed)
@@ -206,12 +206,12 @@ if (process_n) {
   # N price
   #++++++++++++++++
   if ("price" %in% names(input_data_n)) {
-    n_price <- input_data_n[, price]
+    n_price <- as.numeric(input_data_n[, price])
   } else {
     n_price <- NA
   }
 
-  if(!is.numeric(n_price)) {
+  if(is.na(n_price) == TRUE) {
     n_price <- 0.4
   }
 
@@ -274,12 +274,12 @@ if (process_k) {
   # k price
   #++++++++++++++++
   if ("price" %in% names(input_data_k)) {
-    k_price <- input_data_k[, price]
+    k_price <- as.numeric(input_data_k[, price])
   } else {
     k_price <- NA
   }
 
-  if(!is.numeric(k_price)) {
+  if(is.na(k_price) == TRUE) {
     k_price <- 0.4
   }
 


### PR DESCRIPTION
When we bring the field_parameter.json into this code, sometimes the crop_price changes from numeric in the json to string in R. This results in the default price being used instead of the farmer's price despite the fact that we have their price. I'm adding as.numeric() to the process of defining the prices. This will force any strings, such as those from the default field template, to NA, which will receive the default price.