### PR TITLE
Adding new possible nitrogen names

### DIFF
--- a/TrialDesignGeneration/assign-rates.Rmd
+++ b/TrialDesignGeneration/assign-rates.Rmd
@@ -65,7 +65,7 @@ trial_data_r <- trial_data_eh %>%
   mutate(input_type = list(
     case_when(
       form == "seed" ~ "S",
-      form %in% c("uan28", "uan32", "urea", "NH3") ~ "N",
+      form %in% c("uan28", "uan32", "urea", "NH3", "1_2_1(36)", "LAN(26)", "MAP", "1_0_0", "1_0_1", "2_3_2(22)", "15_10_6", "3_0_1", "2_3_4(32)", "4_3_4(33)", "5_1_5", "Sp") ~ "N",
       #=== needs to change this ===#
       form == c("potash") ~ "K"
     )
@@ -81,7 +81,7 @@ trial_data_r <- trial_data_eh %>%
       "rate",
       case_when(
         form == "seed" ~ "tgts_K",
-        form %in% c("uan28", "uan32", "urea", "NH3") ~ "tgtn",
+        form %in% c("uan28", "uan32", "urea", "NH3", , "1_2_1(36)", "LAN(26)", "MAP", "1_0_0", "1_0_1", "2_3_2(22)", "15_10_6", "3_0_1", "2_3_4(32)", "4_3_4(33)", "5_1_5", "Sp") ~ "tgtn",
         #=== needs to change this ===#
         form == c("potash") ~ "tgtk"
       )


### PR DESCRIPTION
Assigning the rates has only 4 names allowed for nitrogen right now, and we need to expand the options for fertilizers used by South African farmers