### PR TITLE
Update yield integration with land units

### DIFF
--- a/DataProcessing/e03_yield_input_integration.Rmd
+++ b/DataProcessing/e03_yield_input_integration.Rmd
@@ -141,7 +141,7 @@ input_pct$gg_dev
 
 ```{r }
 #=== convert max_dev_table if in ha instead of ac ===#
-if(units == "metric"){
+if(w_field_data$land_unit == "ha"){
   max_dev_table %>%
     mutate(max_dev_allowed = max_dev_allowed*2.47105)
 }


### PR DESCRIPTION
Previously, we used the overal "units" to define if the max_dev should be in acres or hectares. Since we now allow different units of distance and width, this update uses the land_unit from field_parameter to determine if the max_dev_table should be converted.